### PR TITLE
CSP-29 Implements select a standard for add standard journey (#53)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 /src/SFA.DAS.Roatp.CourseManagement.Web/appsettings.Development.json
+.DS_Store

--- a/src/SFA.DAS.Roatp.CourseManagement.Application.UnitTests/ProviderStandards/Queries/GetAvailableProviderStandards/GetAvailableProviderStandardsQueryHandlerTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Application.UnitTests/ProviderStandards/Queries/GetAvailableProviderStandards/GetAvailableProviderStandardsQueryHandlerTests.cs
@@ -1,0 +1,31 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Roatp.CourseManagement.Application.ProviderStandards.Queries.GetAvailableProviderStandards;
+using SFA.DAS.Roatp.CourseManagement.Domain.Interfaces;
+using SFA.DAS.Testing.AutoFixture;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Roatp.CourseManagement.Application.UnitTests.ProviderStandards.Queries.GetAvailableProviderStandards
+{
+    [TestFixture]
+    public class GetAvailableProviderStandardsQueryHandlerTests
+    {
+        [Test, MoqAutoData]
+        public async Task Handler_CallsApiClient_ReturnsResult(
+            [Frozen] Mock<IApiClient> apiClientMock,
+            GetAvailableProviderStandardsQueryResult expectedResult,
+            GetAvailableProviderStandardsQuery request,
+            GetAvailableProviderStandardsQueryHandler sut)
+        {
+            apiClientMock.Setup(a => a.Get<GetAvailableProviderStandardsQueryResult>($"providers/{request.Ukprn}/available-courses")).ReturnsAsync(expectedResult);
+            
+            var actualResult = await sut.Handle(request, new CancellationToken());
+
+            apiClientMock.VerifyAll();
+            expectedResult.Should().BeEquivalentTo(actualResult);
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Application/ProviderStandards/Queries/GetAvailableProviderStandards/GetAvailableProviderStandardsQuery.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Application/ProviderStandards/Queries/GetAvailableProviderStandards/GetAvailableProviderStandardsQuery.cs
@@ -1,0 +1,13 @@
+﻿using MediatR;
+
+namespace SFA.DAS.Roatp.CourseManagement.Application.ProviderStandards.Queries.GetAvailableProviderStandards
+{
+    public class GetAvailableProviderStandardsQuery: IRequest<GetAvailableProviderStandardsQueryResult>
+    {
+        public int Ukprn { get; }
+        public GetAvailableProviderStandardsQuery(int ukprn)
+        {
+            Ukprn = ukprn;
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Application/ProviderStandards/Queries/GetAvailableProviderStandards/GetAvailableProviderStandardsQueryHandler.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Application/ProviderStandards/Queries/GetAvailableProviderStandards/GetAvailableProviderStandardsQueryHandler.cs
@@ -1,0 +1,27 @@
+﻿using MediatR;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.Roatp.CourseManagement.Domain.Interfaces;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Roatp.CourseManagement.Application.ProviderStandards.Queries.GetAvailableProviderStandards
+{
+    public class GetAvailableProviderStandardsQueryHandler : IRequestHandler<GetAvailableProviderStandardsQuery, GetAvailableProviderStandardsQueryResult>
+    {
+        private readonly IApiClient _apiClient;
+        private readonly ILogger<GetAvailableProviderStandardsQueryHandler> _logger;
+
+        public GetAvailableProviderStandardsQueryHandler(IApiClient apiClient, ILogger<GetAvailableProviderStandardsQueryHandler> logger)
+        {
+            _apiClient = apiClient;
+            _logger = logger;
+        }
+
+        public async Task<GetAvailableProviderStandardsQueryResult> Handle(GetAvailableProviderStandardsQuery request, CancellationToken cancellationToken)
+        {
+            var result = await _apiClient.Get<GetAvailableProviderStandardsQueryResult>($"providers/{request.Ukprn}/available-courses");
+            _logger.LogInformation("Found {count} available courses for ukprn: {ukprn}", result.AvailableCourses.Count, request.Ukprn);
+            return result;
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Application/ProviderStandards/Queries/GetAvailableProviderStandards/GetAvailableProviderStandardsQueryResult.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Application/ProviderStandards/Queries/GetAvailableProviderStandards/GetAvailableProviderStandardsQueryResult.cs
@@ -1,0 +1,10 @@
+﻿using SFA.DAS.Roatp.CourseManagement.Domain.ApiModels;
+using System.Collections.Generic;
+
+namespace SFA.DAS.Roatp.CourseManagement.Application.ProviderStandards.Queries.GetAvailableProviderStandards
+{
+    public class GetAvailableProviderStandardsQueryResult
+    {
+        public List<StandardLookupModel> AvailableCourses { get; set; } = new List<StandardLookupModel>();
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Domain/ApiModels/StandardLookupModel.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Domain/ApiModels/StandardLookupModel.cs
@@ -1,0 +1,9 @@
+﻿namespace SFA.DAS.Roatp.CourseManagement.Domain.ApiModels
+{
+    public class StandardLookupModel
+    {
+        public int LarsCode { get; set; }
+        public string Title { get; set; }
+        public int Level { get; set; }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/SelectAStandardControllerTests/SelectAStandardControllerGetTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/SelectAStandardControllerTests/SelectAStandardControllerGetTests.cs
@@ -1,0 +1,45 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Roatp.CourseManagement.Application.ProviderStandards.Queries.GetAvailableProviderStandards;
+using SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard;
+using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure;
+using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard;
+using SFA.DAS.Roatp.CourseManagement.Web.UnitTests.TestHelpers;
+using SFA.DAS.Testing.AutoFixture;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.SelectAStandardControllerTests
+{
+    [TestFixture]
+    public class SelectAStandardControllerGetTests
+    {
+        [Test, MoqAutoData]
+        public async Task SelectAStandard_ReturnsViewResult(
+            [Frozen] Mock<IMediator> mediatorMock,
+            [Greedy] SelectAStandardController sut,
+            GetAvailableProviderStandardsQueryResult queryResult)
+        {
+            sut
+                .AddDefaultContextWithUser()
+                .AddUrlHelperMock()
+                .AddUrlForRoute(RouteNames.ViewStandards);
+            mediatorMock.Setup(m => m.Send(It.Is<GetAvailableProviderStandardsQuery>(q => q.Ukprn.ToString() == TestConstants.DefaultUkprn), It.IsAny<CancellationToken>())).ReturnsAsync(queryResult);
+
+            var response = await sut.SelectAStandard();
+
+            var viewResult = response as ViewResult;
+            Assert.IsNotNull(viewResult);
+            viewResult.ViewName.Should().Be(SelectAStandardController.ViewPath);
+            var model = viewResult.Model as SelectAStandardViewModel;
+            model.CancelLink.Should().Be(TestConstants.DefaultUrl);
+            var expectedNames = queryResult.AvailableCourses.Select(s => $"{s.Title} (Level {s.Level})");
+            model.Standards.All(s => expectedNames.Contains(s.Text)).Should().BeTrue();
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/SelectAStandardControllerTests/SelectAStandardControllerPostTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/SelectAStandardControllerTests/SelectAStandardControllerPostTests.cs
@@ -1,0 +1,46 @@
+﻿using AutoFixture.NUnit3;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Roatp.CourseManagement.Application.ProviderStandards.Queries.GetAvailableProviderStandards;
+using SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard;
+using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure;
+using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard;
+using SFA.DAS.Roatp.CourseManagement.Web.UnitTests.TestHelpers;
+using SFA.DAS.Testing.AutoFixture;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.SelectAStandardControllerTests
+{
+    [TestFixture]
+    public class SelectAStandardControllerPostTests
+    {
+        [Test, MoqAutoData]
+        public async Task SubmitAStandard_InvalidState_ReturnsViewResult(
+            [Frozen] Mock<IMediator> mediatorMock,
+            [Greedy] SelectAStandardController sut,
+            GetAvailableProviderStandardsQueryResult queryResult)
+        {
+            sut
+                .AddDefaultContextWithUser()
+                .AddUrlHelperMock()
+                .AddUrlForRoute(RouteNames.ViewStandards);
+            sut.ModelState.AddModelError("key", "message");
+            mediatorMock.Setup(m => m.Send(It.Is<GetAvailableProviderStandardsQuery>(q => q.Ukprn.ToString() == TestConstants.DefaultUkprn), It.IsAny<CancellationToken>())).ReturnsAsync(queryResult);
+
+            var response = await sut.SubmitAStandard(new SelectAStandardSubmitModel());
+
+            var viewResult = response as ViewResult;
+            Assert.IsNotNull(viewResult);
+            viewResult.ViewName.Should().Be(SelectAStandardController.ViewPath);
+            var model = viewResult.Model as SelectAStandardViewModel;
+            model.CancelLink.Should().Be(TestConstants.DefaultUrl);
+            var expectedNames = queryResult.AvailableCourses.Select(s => $"{s.Title} (Level {s.Level})");
+            model.Standards.All(s => expectedNames.Contains(s.Text)).Should().BeTrue();
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/StandardsControllerTests/ViewStandardsTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/StandardsControllerTests/ViewStandardsTests.cs
@@ -13,7 +13,9 @@ using SFA.DAS.Roatp.CourseManagement.Web.Controllers;
 using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure;
 using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure.Authorization;
 using SFA.DAS.Roatp.CourseManagement.Web.Models.Standards;
+using SFA.DAS.Roatp.CourseManagement.Web.UnitTests.TestHelpers;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading;
@@ -27,17 +29,15 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.StandardsCont
         private StandardsController _controller;
         private Mock<ILogger<StandardsController>> _logger;
         private Mock<IMediator> _mediator;
-        private Mock<IUrlHelper> urlHelper;
-        string verifyUrl = "http://test";
-        string verifyStandardUrl = "http://test-standard";
-        string confirmRegulatedStandardUrl = "http://confirm-regulated-standard";
+        private static string ReviewYourDetailsLink = Guid.NewGuid().ToString();
+        private static string GetStandardDetailsLink = Guid.NewGuid().ToString();
+        private static string GetConfirmRegulatedStandardLink = Guid.NewGuid().ToString();
+        private static string AddAStandardLink = Guid.NewGuid().ToString();
+
         [SetUp]
         public void Before_each_test()
         {
             _logger = new Mock<ILogger<StandardsController>>();
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(ProviderClaims.ProviderUkprn, "111"), }, "mock"));
-
-            var response = new System.Collections.Generic.List<Standard>();
 
             var standard1 = new Standard
             {
@@ -45,7 +45,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.StandardsCont
                 CourseName = "test1",
                 Level = 1,
                 IsImported = true,
-                ApprovalBody = "TestBody1"
+                ApprovalBody = "TestBody1",
             };
             var standard2 = new Standard
             {
@@ -53,60 +53,24 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.StandardsCont
                 CourseName = "test2",
                 Level = 2,
                 IsImported = false,
-                ApprovalBody = "TestBody1"
+                ApprovalBody = null
             };
-            response.Add(standard1);
-            response.Add(standard2);
 
             _mediator = new Mock<IMediator>();
             _mediator.Setup(x => x.Send(It.IsAny<GetAllProviderStandardsQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(() => new GetAllProviderStandardsQueryResult
                 {
-                    Standards = response
+                    Standards = new List<Standard> { standard1, standard2 }
                 });
 
-            _controller = new StandardsController(_mediator.Object,  _logger.Object)
-            {
-                ControllerContext = new ControllerContext()
-                {
-                    HttpContext = new DefaultHttpContext() { User = user },
-                },
-                TempData = Mock.Of<ITempDataDictionary>()
-            };
-            urlHelper = new Mock<IUrlHelper>();
-
-            UrlRouteContext verifyRouteValues2 = null;
-            urlHelper
-                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c=>c.RouteName.Equals(RouteNames.GetStandardDetails))
-                ))
-                .Returns(verifyStandardUrl)
-                .Callback<UrlRouteContext>(c =>
-                {
-                    verifyRouteValues2 = c;
-                });
-
-            urlHelper
-                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c => c.RouteName.Equals(RouteNames.GetConfirmRegulatedStandard))
-                ))
-                .Returns(confirmRegulatedStandardUrl)
-                .Callback<UrlRouteContext>(c =>
-                {
-                    verifyRouteValues2 = c;
-                });
-
-
-            UrlRouteContext verifyRouteValues = null;
-            urlHelper
-               .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c =>
-                   c.RouteName.Equals(RouteNames.ReviewYourDetails)
-               )))
-               .Returns(verifyUrl)
-               .Callback<UrlRouteContext>(c =>
-               {
-                   verifyRouteValues = c;
-               });
-
-            _controller.Url = urlHelper.Object;
+            _controller = new StandardsController(_mediator.Object, _logger.Object);
+            _controller
+                .AddDefaultContextWithUser()
+                .AddUrlHelperMock()
+                .AddUrlForRoute(RouteNames.GetStandardDetails, GetStandardDetailsLink)
+                .AddUrlForRoute(RouteNames.GetConfirmRegulatedStandard, GetConfirmRegulatedStandardLink)
+                .AddUrlForRoute(RouteNames.ReviewYourDetails, ReviewYourDetailsLink)
+                .AddUrlForRoute(RouteNames.GetAddStandardSelectStandard, AddAStandardLink);
         }
 
         [Test]
@@ -121,37 +85,11 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.StandardsCont
             var model = viewResult.Model as StandardListViewModel;
             model.Should().NotBeNull();
             model.Standards.Should().NotBeNull();
-            model.BackUrl.Should().Be(verifyUrl);
-            model.Standards.First().StandardUrl.Should().Be(verifyStandardUrl);
+            model.BackLink.Should().Be(ReviewYourDetailsLink);
+            model.Standards.First().StandardUrl.Should().Be(GetStandardDetailsLink);
             model.Standards.First().IsRegulatedStandard.Should().BeTrue();
-            model.Standards.First().ConfirmRegulatedStandardUrl.Should().Be(confirmRegulatedStandardUrl);
-        }
-
-        [Test]
-        public async Task StandardsController_ViewStandards_ReturnsValidResponse_withNoConfirmedRegulatedStandardUrl()
-        {
-            urlHelper = new Mock<IUrlHelper>();
-            UrlRouteContext verifyRouteValues = null;
-            urlHelper
-                .Setup(m => m.RouteUrl(It.Is<UrlRouteContext>(c => c.RouteName.Equals(RouteNames.GetConfirmRegulatedStandard))
-                ))
-                .Returns((string)null)
-                .Callback<UrlRouteContext>(c =>
-                {
-                    verifyRouteValues = c;
-                });
-
-            _controller.Url = urlHelper.Object;
-            var result = await _controller.ViewStandards();
-
-            var viewResult = result as ViewResult;
-            viewResult.Should().NotBeNull();
-            viewResult.ViewName.Should().Contain("ViewStandards.cshtml");
-            viewResult.Model.Should().NotBeNull();
-            var model = viewResult.Model as StandardListViewModel;
-            model.Should().NotBeNull();
-            model.Standards.Should().NotBeNull();
-            model.Standards.First().ConfirmRegulatedStandardUrl.Should().BeNull();
+            model.Standards.First().ConfirmRegulatedStandardUrl.Should().Be(GetConfirmRegulatedStandardLink);
+            model.Standards.Last().ConfirmRegulatedStandardUrl.Should().Be(String.Empty);
         }
 
         [Test]
@@ -159,17 +97,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.StandardsCont
         {
             _mediator.Setup(x => x.Send(It.IsAny<GetAllProviderStandardsQuery>(), It.IsAny<CancellationToken>()))
                      .ReturnsAsync(() => null);
-            var user = new ClaimsPrincipal(new ClaimsIdentity(new Claim[]{ new Claim(ProviderClaims.ProviderUkprn,"111"),}, "mock"));
             
-            _controller = new StandardsController(_mediator.Object, _logger.Object)
-            {
-                ControllerContext = new ControllerContext()
-                {
-                    HttpContext = new DefaultHttpContext() { User = user },
-                },
-                TempData = Mock.Of<ITempDataDictionary>()
-            };
-            _controller.Url = urlHelper.Object;
             var result = await _controller.ViewStandards();
 
             var viewResult = result as ViewResult;
@@ -179,7 +107,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.StandardsCont
             var model = viewResult.Model as StandardListViewModel;
             model.Should().NotBeNull();
             model.Standards.Should().BeEmpty();
-            model.BackUrl.Should().Be(verifyUrl);
+            model.BackLink.Should().Be(ReviewYourDetailsLink);
             _logger.Verify(x => x.Log(LogLevel.Information, It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>()), Times.Exactly(2));
         }
     }

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Validators/AddAStandard/SelectAStandardSubmitModelValidatorTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Validators/AddAStandard/SelectAStandardSubmitModelValidatorTests.cs
@@ -1,0 +1,26 @@
+﻿using FluentValidation.TestHelper;
+using NUnit.Framework;
+using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard;
+using SFA.DAS.Roatp.CourseManagement.Web.Validators.AddAStandard;
+
+namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Validators.AddAStandard
+{
+    [TestFixture]
+    public class SelectAStandardSubmitModelValidatorTests
+    {
+        [TestCase(0, false)]
+        [TestCase(12, true)]
+        public void SelectedLarsCode_Validation(int larsCode, bool isValid)
+        {
+            var model = new SelectAStandardSubmitModel() { SelectedLarsCode = larsCode };
+            var sut = new SelectAStandardSubmitModelValidator();
+
+            var result = sut.TestValidate(model);
+
+            if (isValid)
+                result.ShouldNotHaveValidationErrorFor(m => m.SelectedLarsCode);
+            else
+                result.ShouldHaveValidationErrorFor(m => m.SelectedLarsCode);
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/SelectAStandardController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/SelectAStandardController.cs
@@ -1,0 +1,59 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.Authorization.Mvc.Attributes;
+using SFA.DAS.Roatp.CourseManagement.Application.ProviderStandards.Queries.GetAvailableProviderStandards;
+using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure;
+using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure.Authorization;
+using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard
+{
+    [DasAuthorize(new[] { "ProviderFeature.CourseManagement" }, Policy = nameof(PolicyNames.HasProviderAccount))]
+    public class SelectAStandardController : ControllerBase
+    {
+        public const string ViewPath = "~/Views/AddAStandard/SelectAStandard.cshtml";
+        private readonly ILogger<SelectAStandardController> _logger;
+        private readonly IMediator _mediator;
+
+        public SelectAStandardController(ILogger<SelectAStandardController> logger, IMediator mediator)
+        {
+            _logger = logger;
+            _mediator = mediator;
+        }
+
+        [Route("{ukprn}/standards/new-standard", Name = RouteNames.GetAddStandardSelectStandard)]
+        [HttpGet]
+        public async Task<IActionResult> SelectAStandard()
+        {
+            var model = await GetModel();
+            return View(ViewPath, model);
+        }
+
+        [Route("{ukprn}/standards/new-standard", Name = RouteNames.PostAddStandardSelectStandard)]
+        [HttpPost]
+        public async Task<IActionResult> SubmitAStandard(SelectAStandardSubmitModel submitModel)
+        {
+            if (!ModelState.IsValid)
+            {
+                var model = await GetModel();
+                return View(ViewPath, model);
+            }
+            _logger.LogInformation("Begin of jounrey for ukprn: {ukprn} to add standard {larscode}", Ukprn, submitModel.SelectedLarsCode);
+
+            return Ok();
+        }
+
+        private async Task<SelectAStandardViewModel> GetModel()
+        {
+            var result = await _mediator.Send(new GetAvailableProviderStandardsQuery(Ukprn));
+            var model = new SelectAStandardViewModel();
+            model.Standards = result.AvailableCourses.OrderBy(c => c.Title).Select(s => new SelectListItem($"{s.Title} (Level {s.Level})", s.LarsCode.ToString()));
+            model.CancelLink = Url.RouteUrl(RouteNames.ViewStandards, new { Ukprn });
+            return model;
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/StandardsController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/StandardsController.cs
@@ -36,8 +36,8 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers
 
             var model = new StandardListViewModel
             {
-                BackUrl = Url.RouteUrl(RouteNames.ReviewYourDetails, new
-                { ukprn = Ukprn })
+                BackLink = Url.RouteUrl(RouteNames.ReviewYourDetails, new { Ukprn }),
+                AddAStandardLink = Url.RouteUrl(RouteNames.GetAddStandardSelectStandard, new { Ukprn })
             };
 
             if (result == null)
@@ -51,7 +51,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers
             foreach (var standard in model.Standards)
             {
                 standard.StandardUrl = Url.RouteUrl(RouteNames.GetStandardDetails, new {Ukprn, larsCode = standard.LarsCode});
-                standard.ConfirmRegulatedStandardUrl = standard.IsRegulatedStandard ? Url.RouteUrl(RouteNames.GetConfirmRegulatedStandard, new { Ukprn, standard.LarsCode }) : string.Empty;
+                standard.ConfirmRegulatedStandardUrl = standard.IsApprovalPending ? Url.RouteUrl(RouteNames.GetConfirmRegulatedStandard, new { Ukprn, standard.LarsCode }) : string.Empty;
             }
 
             return View("~/Views/Standards/ViewStandards.cshtml", model);

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Infrastructure/RouteNames.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Infrastructure/RouteNames.cs
@@ -26,6 +26,9 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Infrastructure
         public const string GetRemoveProviderCourseLocation = "GetRemoveProviderCourseLocation";
         public const string PostRemoveProviderCourseLocation = "PostRemoveProviderCourseLocation";
 
+        public const string GetAddStandardSelectStandard = "GetAddStandardSelectStandard";
+        public const string PostAddStandardSelectStandard = "PostAddStandardSelectStandard";
+
         public const string GetTrainingLocationPostcode = "GetTrainingLocationPostcode";
         public const string PostTrainingLocationPostcode = "PostTrainingLocationPostcode";
         public const string GetProviderLocationAddress = "GetTrainingLocationAddress";

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Models/AddAStandard/SelectAStandardViewModel.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Models/AddAStandard/SelectAStandardViewModel.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Collections.Generic;
+
+namespace SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard
+{
+    public class SelectAStandardViewModel : SelectAStandardSubmitModel
+    {
+        public string CancelLink { get; set; }
+        public IEnumerable<SelectListItem> Standards { get; set; }
+    }
+
+    public class SelectAStandardSubmitModel
+    {
+        public int SelectedLarsCode { get; set; }
+
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Models/Standards/StandardListViewModel.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Models/Standards/StandardListViewModel.cs
@@ -5,6 +5,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Models.Standards
     public class StandardListViewModel 
     {
         public List<StandardViewModel> Standards { get; set; } = new List<StandardViewModel>();
-        public string BackUrl { get; set; }
+        public string BackLink { get; set; }
+        public string AddAStandardLink { get; set; }
     }
 }

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Validators/AddAStandard/SelectAStandardSubmitModelValidator.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Validators/AddAStandard/SelectAStandardSubmitModelValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard;
+
+namespace SFA.DAS.Roatp.CourseManagement.Web.Validators.AddAStandard
+{
+    public class SelectAStandardSubmitModelValidator : AbstractValidator<SelectAStandardSubmitModel>
+    {
+        public const string StandardIsRequiredMesssage = "Start typing the name of the standard in the box";
+        public SelectAStandardSubmitModelValidator()
+        {
+            RuleFor(m => m.SelectedLarsCode)
+                .NotEmpty()
+                .WithMessage(StandardIsRequiredMesssage);
+        }
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/SelectAStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/SelectAStandard.cshtml
@@ -1,0 +1,28 @@
+﻿@using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard
+@model SelectAStandardViewModel
+@{
+    ViewBag.Title = "Select a standard";
+    ViewBag.Description = "";
+}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <partial name="_validationSummary" />
+        <div class="govuk-caption-xl">Add a standard</div>
+        <h1 class="govuk-heading-xl">Select a standard</h1>
+
+        <form method="post" asp-route="@RouteNames.PostAddStandardSelectStandard" enctype="multipart/form-data" novalidate>
+            <div esfa-validation-marker-for="SelectedLarsCode" class="govuk-form-group">
+                <label class="govuk-label govuk-label--m" asp-for="Standards">
+                    To add a standard, start typing in the box and its name will appear.
+                </label>
+                <span asp-validation-for="SelectedLarsCode" class="govuk-error-message"></span>
+                <select asp-for="SelectedLarsCode" asp-items="@Model.Standards" class="govuk-select app-autocomplete" data-placeholder="Start typing the name of the standard"></select>
+            </div>
+
+            <div class="govuk-button-group">
+                <button id="submit" type="submit" class="govuk-button">Continue</button>
+                <a href="@Model.CancelLink" class="govuk-link">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/SelectAStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/SelectAStandard.cshtml
@@ -12,7 +12,7 @@
 
         <form method="post" asp-route="@RouteNames.PostAddStandardSelectStandard" enctype="multipart/form-data" novalidate>
             <div esfa-validation-marker-for="SelectedLarsCode" class="govuk-form-group">
-                <label class="govuk-label govuk-label--m" asp-for="Standards">
+                <label class="govuk-label" asp-for="Standards">
                     To add a standard, start typing in the box and its name will appear.
                 </label>
                 <span asp-validation-for="SelectedLarsCode" class="govuk-error-message"></span>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/SelectAStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/SelectAStandard.cshtml
@@ -16,7 +16,9 @@
                     To add a standard, start typing in the box and its name will appear.
                 </label>
                 <span asp-validation-for="SelectedLarsCode" class="govuk-error-message"></span>
-                <select asp-for="SelectedLarsCode" asp-items="@Model.Standards" class="govuk-select app-autocomplete" data-placeholder="Start typing the name of the standard"></select>
+                <select asp-for="SelectedLarsCode" asp-items="@Model.Standards" class="govuk-select app-autocomplete" data-placeholder="Start typing the name of the standard">
+                  <option value="" disabled selected></option>
+                </select>
             </div>
 
             <div class="govuk-button-group">

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Shared/_ProviderLayout.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Shared/_ProviderLayout.cshtml
@@ -2,7 +2,6 @@
     Layout = "_Layout.cshtml";
 }
 
-<partial name="_FlashMessagePartial" />
 @RenderBody()
 
 @section Styles

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Shared/_ProviderLayout.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Shared/_ProviderLayout.cshtml
@@ -1,0 +1,24 @@
+@{
+    Layout = "_Layout.cshtml";
+}
+
+<partial name="_FlashMessagePartial" />
+@RenderBody()
+
+@section Styles
+{
+    @RenderSection("Styles", required: false)
+    <link href="/css/app.css" rel="stylesheet" no-cdn />
+}
+
+@section breadcrumb
+{
+    @RenderSection("breadcrumb", required: false)
+}
+
+@section Scripts
+{
+    @RenderSection("Scripts", required: false)
+    <script src="libs/accessible-autocomplete/accessible-autocomplete.min.js"></script>
+    <script src="/js/app.js" no-cdn></script>
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ViewStandards.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ViewStandards.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section breadcrumb {
-    <a class="govuk-back-link" href="#">Back</a>
+    <a class="govuk-back-link" href="@Model.BackLink">Back</a>
 }
 
 <div class="grid-row">
@@ -43,8 +43,8 @@
                 }
             </tbody>
         </table>
-        <p class="govuk-body" style="display: none; visibility: hidden">
-            <a href="#" class="govuk-link">
+        <p class="govuk-body">
+            <a href="@Model.AddAStandardLink" class="govuk-link">
                 Add a standard
             </a>
         </p>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/_ViewStart.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/_ViewStart.cshtml
@@ -1,3 +1,3 @@
 ﻿@{
-    Layout = "_Layout";
+    Layout = "_ProviderLayout";
 }

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/wwwroot/css/app.css
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/wwwroot/css/app.css
@@ -16,9 +16,8 @@
 }
 
 @media (min-width: 40.0625em) {
-    .autocomplete__wrapper {
-        width: 75%;
-    }
+    .autocomplete__wrapper {}
+
     .das-search-form__group .autocomplete__wrapper {
         width: 100%;
     }

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/wwwroot/css/app.css
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/wwwroot/css/app.css
@@ -1,0 +1,25 @@
+.autocomplete__dropdown-arrow-down-wrapper {
+    position: absolute;
+    top: 7px;
+    right: 7px;
+}
+
+@media (min-width: 40.0625em) {
+    .autocomplete__dropdown-arrow-down-wrapper {
+        top: 9px;
+        right: 9px;
+    }
+}
+
+.das-search-form__group .autocomplete__input {
+    height: 40px;
+}
+
+@media (min-width: 40.0625em) {
+    .autocomplete__wrapper {
+        width: 75%;
+    }
+    .das-search-form__group .autocomplete__wrapper {
+        width: 100%;
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/wwwroot/js/app.js
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/wwwroot/js/app.js
@@ -1,0 +1,47 @@
+
+$(function () {
+
+  // Autocomplete on dropdowns  
+
+  var selectElements = $('.app-autocomplete')
+    selectElements.each(function () {
+        var form = $(this).closest('form');
+
+        accessibleAutocomplete.enhanceSelectElement({
+            selectElement: this,
+            minLength: 3,
+            autoselect: false,
+            defaultValue: '',
+            showAllValues: true,
+            displayMenu: 'overlay',
+            dropdownArrow: function () {
+                return '<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M13.4271 15.4271C12.0372 16.4175 10.3367 17 8.5 17C3.80558 17 0 13.1944 0 8.5C0 3.80558 3.80558 0 8.5 0C13.1944 0 17 3.80558 17 8.5C17 10.3367 16.4175 12.0372 15.4271 13.4271L21.0119 19.0119C21.5621 19.5621 21.5575 20.4425 21.0117 20.9883L20.9883 21.0117C20.4439 21.5561 19.5576 21.5576 19.0119 21.0119L13.4271 15.4271ZM8.5 15C12.0899 15 15 12.0899 15 8.5C15 4.91015 12.0899 2 8.5 2C4.91015 2 2 4.91015 2 8.5C2 12.0899 4.91015 15 8.5 15Z" fill="#b1b4b6"/></svg>';
+            },
+            placeholder: $(this).data('placeholder') || '',
+            onConfirm: function (opt) {
+                var txtInput = document.querySelector('#' + this.id);
+                var searchString = opt || txtInput.value;
+                var requestedOption = [].filter.call(this.selectElement.options,
+                    function (option) {
+                        return (option.textContent || option.innerText) === searchString
+                    }
+                )[0];
+                if (requestedOption) {
+                    requestedOption.selected = true;
+                } else {
+                    this.selectElement.selectedIndex = 0;
+                }
+            }
+        });
+        form.on('submit', function() {
+            $('.autocomplete__input').each(function() {
+                var that = $(this);
+                if (that.val().length === 0) {
+                    var fieldId = that.attr('id'),
+                    selectField = $('#' + fieldId + '-select');
+                    selectField[0].selectedIndex = 0;
+                }
+            });
+        });
+    })
+});


### PR DESCRIPTION
* CSP-29 Enabled link to Add a standard

* CSP-51 Added handler to retrieve available standards for provider

* CSP-51 Added model and validator for select a standard

* CSP-51 Implemented GET endpoint for select a standard

* Ignore hidden mac files

* Additional layout file so we can load local css and js

* Add placeholder text to autocomplete control

Co-authored-by: James King <hello@jamesmichaelking.com>