### PR TITLE
CSP-190 Enable both location option in add standard journey

### DIFF
--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/AddStandardAddRegionsControllerTests/AddStandardAddRegionsControllerGetTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/AddStandardAddRegionsControllerTests/AddStandardAddRegionsControllerGetTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.Roatp.CourseManagement.Application.Regions.Queries;
+using SFA.DAS.Roatp.CourseManagement.Domain.Models;
 using SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard;
 using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure;
 using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard;
@@ -30,6 +31,38 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.
             var result = await sut.SelectRegions();
 
             result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.GetAddStandardSelectStandard);
+        }
+
+        [Test, MoqAutoData]
+        public async Task SelectRegions_LocationOptionIsProvider_RedirectsToViewStandard(
+            [Frozen] Mock<ISessionService> sessionServiceMock,
+            [Greedy] AddStandardAddRegionsController sut,
+            StandardSessionModel standardSessionModel)
+        {
+            standardSessionModel.LocationOption = LocationOption.ProviderLocation;
+            standardSessionModel.HasNationalDeliveryOption = false;
+            sut.AddDefaultContextWithUser();
+            sessionServiceMock.Setup(s => s.Get<StandardSessionModel>(TestConstants.DefaultUkprn)).Returns(standardSessionModel);
+
+            var result = await sut.SelectRegions();
+
+            result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.ViewStandards);
+        }
+
+        [Test, MoqAutoData]
+        public async Task SelectRegions_NationalDeliveryOptionIsTrue_RedirectsToViewStandard(
+            [Frozen] Mock<ISessionService> sessionServiceMock,
+            [Greedy] AddStandardAddRegionsController sut,
+            StandardSessionModel standardSessionModel)
+        {
+            standardSessionModel.LocationOption = LocationOption.EmployerLocation;
+            standardSessionModel.HasNationalDeliveryOption = true;
+            sut.AddDefaultContextWithUser();
+            sessionServiceMock.Setup(s => s.Get<StandardSessionModel>(TestConstants.DefaultUkprn)).Returns(standardSessionModel);
+
+            var result = await sut.SelectRegions();
+
+            result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.ViewStandards);
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/ConfirmNationalProviderControllerTests/ConfirmNationalProviderControllerGetTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/ConfirmNationalProviderControllerTests/ConfirmNationalProviderControllerGetTests.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.
         }
 
         [Test, MoqAutoData]
-        public void Get_LocationOptionIsProviderLocation_RedirectsTManageStandard(
+        public void Get_LocationOptionIsProviderLocation_RedirectsToManageStandard(
             [Frozen] Mock<ISessionService> sessionServiceMock,
             [Greedy] ConfirmNationalProviderController sut,
             StandardSessionModel sessionModel)

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/ConfirmNationalProviderControllerTests/ConfirmNationalProviderControllerGetTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/ConfirmNationalProviderControllerTests/ConfirmNationalProviderControllerGetTests.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.
         }
 
         [Test, MoqAutoData]
-        public void Get_LocationOptionIsProviderLocation_RedirectsToSelectAStandard(
+        public void Get_LocationOptionIsProviderLocation_RedirectsTManageStandard(
             [Frozen] Mock<ISessionService> sessionServiceMock,
             [Greedy] ConfirmNationalProviderController sut,
             StandardSessionModel sessionModel)
@@ -41,7 +41,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.
 
             var result = sut.ConfirmNationalDeliveryOption();
 
-            result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.GetAddStandardSelectStandard);
+            result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.ViewStandards);
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/ViewTrainingLocationsControllerTests/StandardTrainingLocationsControllerGetTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/ViewTrainingLocationsControllerTests/StandardTrainingLocationsControllerGetTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using AutoFixture.NUnit3;
+﻿using AutoFixture.NUnit3;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
@@ -16,6 +12,8 @@ using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard;
 using SFA.DAS.Roatp.CourseManagement.Web.Services;
 using SFA.DAS.Roatp.CourseManagement.Web.UnitTests.TestHelpers;
 using SFA.DAS.Testing.AutoFixture;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.ViewTrainingLocationsControllerTests
 {
@@ -28,13 +26,28 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.
             [Greedy] StandardTrainingLocationsController sut,
             string cancelLink)
         {
-            sut.AddDefaultContextWithUser().AddUrlHelperMock().AddUrlForRoute(RouteNames.ViewStandards, cancelLink);
+            sut.AddDefaultContextWithUser();
             sessionServiceMock.Setup(s => s.Get<StandardSessionModel>(It.IsAny<string>())).Returns((StandardSessionModel)null);
 
             var result = sut.ViewTrainingLocations();
 
             result.As<RedirectToRouteResult>().Should().NotBeNull();
             result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.GetAddStandardSelectStandard);
+        }
+
+        [Test, MoqAutoData]
+        public void ViewTrainingLocations_IncorrectLocationOptionInSession_RedirectsToStandardsListPage(
+           [Frozen] Mock<ISessionService> sessionServiceMock,
+           [Greedy] StandardTrainingLocationsController sut,
+           StandardSessionModel standardSessionModel)
+        {
+            standardSessionModel.LocationOption = LocationOption.EmployerLocation;
+            sut.AddDefaultContextWithUser();
+            sessionServiceMock.Setup(s => s.Get<StandardSessionModel>(It.IsAny<string>())).Returns(standardSessionModel);
+
+            var result = sut.ViewTrainingLocations();
+
+            result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.ViewStandards);
         }
 
         [Test, MoqAutoData]

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/ViewTrainingLocationsControllerTests/StandardTrainingLocationsControllerPostTests.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.UnitTests/Controllers/AddAStandard/ViewTrainingLocationsControllerTests/StandardTrainingLocationsControllerPostTests.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using NUnit.Framework;
+using SFA.DAS.Roatp.CourseManagement.Domain.Models;
 using SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard;
 using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure;
 using SFA.DAS.Roatp.CourseManagement.Web.Models.AddAStandard;
@@ -52,19 +53,35 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.UnitTests.Controllers.AddAStandard.
         }
 
         [Test, MoqAutoData]
-        public void Submit_ReturnsView(
+        public void Submit_LocationOptionSetToProviders_RedirectsToReviewPage(
             [Frozen] Mock<ISessionService> sessionServiceMock,
             [Greedy] StandardTrainingLocationsController sut,
             StandardSessionModel sessionModel,
             string cancelLink)
         {
+            sessionModel.LocationOption = LocationOption.ProviderLocation;
             sessionServiceMock.Setup(s => s.Get<StandardSessionModel>(It.IsAny<string>())).Returns(sessionModel);
             sut.AddDefaultContextWithUser().AddUrlHelperMock().AddUrlForRoute(RouteNames.GetAddStandardSelectLocationOption, cancelLink);
            
             var result = sut.SubmitTrainingLocations(new TrainingLocationListViewModel());
 
-            result.As<RedirectToRouteResult>().Should().NotBeNull();
             result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.GetAddStandardReviewStandard);
+        }
+
+        [Test, MoqAutoData]
+        public void Submit_LocationOptionSetToBoth_RedirectsToNationalQuestionPage(
+            [Frozen] Mock<ISessionService> sessionServiceMock,
+            [Greedy] StandardTrainingLocationsController sut,
+            StandardSessionModel sessionModel,
+            string cancelLink)
+        {
+            sessionModel.LocationOption = LocationOption.Both;
+            sessionServiceMock.Setup(s => s.Get<StandardSessionModel>(It.IsAny<string>())).Returns(sessionModel);
+            sut.AddDefaultContextWithUser().AddUrlHelperMock().AddUrlForRoute(RouteNames.GetAddStandardSelectLocationOption, cancelLink);
+
+            var result = sut.SubmitTrainingLocations(new TrainingLocationListViewModel());
+
+            result.As<RedirectToRouteResult>().RouteName.Should().Be(RouteNames.GetAddStandardConfirmNationalProvider);
         }
     }
 }

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/AddStandardAddRegionsController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/AddStandardAddRegionsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.Authorization.Mvc.Attributes;
 using SFA.DAS.Roatp.CourseManagement.Application.Regions.Queries;
+using SFA.DAS.Roatp.CourseManagement.Domain.Models;
 using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure;
 using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure.Authorization;
 using SFA.DAS.Roatp.CourseManagement.Web.Models;
@@ -33,6 +34,12 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard
         {
             var (sessionModel, redirectResult) = GetSessionModelWithEscapeRoute(_logger);
             if (sessionModel == null) return redirectResult;
+
+            if (sessionModel.LocationOption == LocationOption.ProviderLocation || sessionModel.HasNationalDeliveryOption.GetValueOrDefault())
+            {
+                _logger.LogWarning($"User: {UserId} unexpectedly landed on regions page when location option is {sessionModel.LocationOption} and national delivery option is {sessionModel.HasNationalDeliveryOption}");
+                return RedirectToRouteWithUkprn(RouteNames.ViewStandards);
+            }
 
             AddStandardAddRegionsViewModel model = await GetViewModel();
             return View(ViewPath, model);

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/AddStandardTrainingLocationController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/AddStandardTrainingLocationController.cs
@@ -36,8 +36,9 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard
         {
             var (sessionModel, redirectResult) = GetSessionModelWithEscapeRoute(_logger);
             if (sessionModel == null) return redirectResult;
+
             var model = await GetModel(sessionModel);
-            if (model == null) return RedirectToRouteWithUkprn(RouteNames.GetAddStandardSelectStandard);
+
             return View(ViewPath, model);
         }
 

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/ConfirmNationalProviderController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/ConfirmNationalProviderController.cs
@@ -30,10 +30,10 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard
             var (sessionModel, redirectResult) = GetSessionModelWithEscapeRoute(_logger);
             if (sessionModel == null) return redirectResult;
 
-            if (sessionModel.LocationOption != LocationOption.EmployerLocation && sessionModel.LocationOption != LocationOption.Both)
+            if (sessionModel.LocationOption == LocationOption.ProviderLocation)
             {
-                _logger.LogInformation("Add standard national option: location option {locationOption} in session does not allow this question, navigating back to select standard", sessionModel.LocationOption);
-                return RedirectToRouteWithUkprn(RouteNames.GetAddStandardSelectStandard);
+                _logger.LogWarning($"User: {UserId} unexpectedly landed on national delivery confirmation page when location option is set to providers.");
+                return RedirectToRouteWithUkprn(RouteNames.ViewStandards);
             }
 
             return View(ViewPath, GetModel());

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/SelectLocationOptionController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/SelectLocationOptionController.cs
@@ -60,7 +60,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard
             {
                 return RedirectToRouteWithUkprn(RouteNames.GetAddStandardConfirmNationalProvider);
             }
-            // If the location option is provider or both then we need to navigate to provider location page which is covered in a follow up story
+
             return RedirectToRouteWithUkprn(RouteNames.GetNewStandardViewTrainingLocationOptions);
         }
 

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/StandardTrainingLocationsController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/AddAStandard/StandardTrainingLocationsController.cs
@@ -37,7 +37,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers.AddAStandard
             //this is protective code as well as allows post method to avoid this check
             if (sessionModel.LocationOption == LocationOption.EmployerLocation)
             {
-                _logger.LogWarning($"User: {UserId} unexpectedly landed on provider location page when location option is set to employers, restarting add journey");
+                _logger.LogWarning($"User: {UserId} unexpectedly landed on provider location page when location option is set to employers.");
                 return RedirectToRouteWithUkprn(RouteNames.ViewStandards);
             }
 


### PR DESCRIPTION
I have been paranoid and added protective code on all location pages 