### PR TITLE
Csp 586 accessibility fixes

### DIFF
--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/AddStandardTrainingLocation.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/AddStandardTrainingLocation.cshtml
@@ -27,7 +27,7 @@
             </div>
 
             <div class="govuk-form-group" esfa-validation-marker-for="HasDayReleaseDeliveryOption">
-                <fieldset class="govuk-fieldset" aria-describedby="DeliveryOption">
+                <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend">
                         Select the delivery method
                     </legend>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/AddStandardTrainingLocation.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/AddStandardTrainingLocation.cshtml
@@ -17,7 +17,7 @@
             <input type="hidden" asp-for="@Model.CancelLink" />
 
             <div esfa-validation-marker-for="TrainingVenueNavigationId" class="govuk-form-group">
-                <label class="govuk-label" asp-for="TrainingVenues">
+                <label class="govuk-label" asp-for="TrainingVenueNavigationId">
                     Select the training venue for this standard.
                 </label>
                 <span asp-validation-for="TrainingVenueNavigationId" class="govuk-error-message"></span>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/ConfirmNonRegulatedStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/ConfirmNonRegulatedStandard.cshtml
@@ -7,19 +7,14 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <partial name="_validationSummary" />
-        <div class="govuk-caption-xl">Add standard</div>
+        <span class="govuk-caption-xl">Add standard</span>
         <partial name="_StandardInformation" for="StandardInformation" />
 
         <form method="post" asp-route="@RouteNames.PostAddStandardConfirmNonRegulatedStandard" enctype="multipart/form-data" novalidate>
             <div esfa-validation-marker-for="IsCorrectStandard" class="govuk-form-group">
                 <span asp-validation-for="IsCorrectStandard" class="govuk-error-message"></span>
-
                 <fieldset class="govuk-fieldset">
-                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                        <h1 class="govuk-fieldset__heading">
-                            Is this the correct standard?
-                        </h1>
-                    </legend>
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Is this the correct standard?</legend>
                     <div id="IsCorrectStandard" class="govuk-radios" data-module="govuk-radios">
                         <div class="govuk-radios__item">
                             <input class="govuk-radios__input" id="is-correct-standard-yes" type="radio" value="true"

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/SelectAStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddAStandard/SelectAStandard.cshtml
@@ -12,7 +12,7 @@
 
         <form method="post" asp-route="@RouteNames.PostAddStandardSelectStandard" enctype="multipart/form-data" novalidate>
             <div esfa-validation-marker-for="SelectedLarsCode" class="govuk-form-group">
-                <label class="govuk-label" asp-for="Standards">
+                <label class="govuk-label" asp-for="SelectedLarsCode">
                     To add a standard, start typing in the box and its name will appear.
                 </label>
                 <span asp-validation-for="SelectedLarsCode" class="govuk-error-message"></span>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddTrainingLocation/AddTrainingLocationDetails.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/AddTrainingLocation/AddTrainingLocationDetails.cshtml
@@ -25,17 +25,17 @@
                     <input asp-for="LocationName" id="LocationName" class="govuk-input" type="text" maxlength="50">
                 </div>
 
-                <div class="govuk-form-group">
-                    <label class="govuk-label govuk-label--m" asp-for="LocationName">
-                        Address
-                    </label>
-                    <p style="govuk-body">
-                        <span>@Model.AddressLine1</span><br>
-                        <span>@Model.AddressLine2</span><br>
-                        <span>@Model.Town</span><br>
-                        <span>@Model.Postcode</span>
-                    </p>
-                </div>
+                
+                <h2 class="govuk-heading-m">
+                    Address
+                </h2>
+                <p class="govuk-body">
+                    <span>@Model.AddressLine1</span><br>
+                    <span>@Model.AddressLine2</span><br>
+                    <span>@Model.Town</span><br>
+                    <span>@Model.Postcode</span>
+                </p>
+       
 
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/EditNationalDeliveryOption/Index.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/EditNationalDeliveryOption/Index.cshtml
@@ -15,7 +15,7 @@
         <h1 class="govuk-heading-xl">Can you deliver this training anywhere in England?</h1>
         <p>If you can, we will show you as a national provider on Find apprenticeship training.</p>
 
-        <nav>
+  
           <details class="govuk-details" data-module="govuk-details">
               <summary class="govuk-details__summary">
                   <span class="govuk-details__summary-text">
@@ -29,7 +29,7 @@
                   We have included nine regions that cover the entire country. If you cannot deliver this standard in all nine, then you are not a national provider.
               </div>
           </details>
-      </nav>
+    
 
         <form method="post" asp-route="@RouteNames.PostNationalDeliveryOption" enctype="multipart/form-data" novalidate>
             <div esfa-validation-marker-for="HasNationalDeliveryOption" class="govuk-form-group">

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/EditProviderLocation/EditProviderLocationsDetails.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/EditProviderLocation/EditProviderLocationsDetails.cshtml
@@ -33,7 +33,7 @@
                 <label class="govuk-label govuk-label--m" asp-for="LocationName">
                     Address
                 </label>
-                <p style="govuk-body">
+                <p class="govuk-body">
                     <span>@Model.AddressLine1</span><br>
                     <span>@Model.AddressLine2</span><br>
                     <span>@Model.Town</span><br>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/EditProviderLocation/ViewProviderLocationsDetails.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/EditProviderLocation/ViewProviderLocationsDetails.cshtml
@@ -13,18 +13,15 @@
     <div class="govuk-grid-column-two-thirds">
         <div class="govuk-caption-xl">Training venue</div>
         <h1 class="govuk-heading-xl">@Model.LocationName</h1>
-
-        <div class="govuk-form-group">
-            <label class="govuk-label govuk-label--l" asp-for="LocationName">
+            <h2 class="govuk-heading-m">
                 Address
-            </label>
-            <p style="govuk-body">
+            </h2>
+            <p class="govuk-body">
                 <span>@Model.AddressLine1</span><br>
                 <span>@Model.AddressLine2</span><br>
                 <span>@Model.Town</span><br>
                 <span>@Model.Postcode</span>
             </p>
-        </div>
 
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
         <h2 class="govuk-heading-l">Venue contact details</h2>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/ProviderCourseLocations/AddTrainingCourseLocation.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/ProviderCourseLocations/AddTrainingCourseLocation.cshtml
@@ -28,7 +28,7 @@
             </div>
 
             <div class="govuk-form-group" esfa-validation-marker-for="HasDayReleaseDeliveryOption">
-                <fieldset class="govuk-fieldset" aria-describedby="DeliveryOption">
+                <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend">
                         Select the delivery method
                     </legend>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/ProviderCourseLocations/RemoveProviderCourseLocation.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/ProviderCourseLocations/RemoveProviderCourseLocation.cshtml
@@ -16,7 +16,7 @@
             <input type="hidden" asp-for="CancelLink" />
             <div class="grid-row">
                 <div class="column-two-thirds">
-                    <table class="govuk-table" aria-describedby="ConfirmRemoveTrainingLocation">
+                    <table class="govuk-table">
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
                                 <th class="govuk-table__header das-table-cell-width-50" scope="col"> Venue name </th>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/ProviderCourseLocations/RemoveProviderCourseLocation.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/ProviderCourseLocations/RemoveProviderCourseLocation.cshtml
@@ -17,6 +17,7 @@
             <div class="grid-row">
                 <div class="column-two-thirds">
                     <table class="govuk-table">
+                        <caption class="govuk-visually-hidden">Venue details</caption>
                         <thead class="govuk-table__head">
                             <tr class="govuk-table__row">
                                 <th class="govuk-table__header das-table-cell-width-50" scope="col"> Venue name </th>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Shared/_StandardInformation.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Shared/_StandardInformation.cshtml
@@ -2,12 +2,8 @@
 @model StandardInformationViewModel
 
 <h1 class="govuk-heading-xl">@Model.CourseDisplayName</h1>
-<table class="govuk-table" aria-label="Coure details">
+<table class="govuk-table" aria-label="Standard details">
     <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-          <th class="govuk-table__header das-table-cell-width-30" scope="row"></th>
-          <td class="govuk-table__cell das-table-cell-width-70"></td>
-        </tr>
         <tr class="govuk-table__row">
             <th class="govuk-table__header das-table-cell-width-30" scope="row">
                 IFATE Reference

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ConfirmDeleteStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ConfirmDeleteStandard.cshtml
@@ -20,6 +20,7 @@
             <input type="hidden" asp-for="StandardInformation.LarsCode" />
 
             <table class="govuk-table">
+                <caption class="govuk-visually-hidden">Details of the standard</caption>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row">
                         <th scope="row" class="govuk-table__header">

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ConfirmDeleteStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ConfirmDeleteStandard.cshtml
@@ -4,115 +4,87 @@
 @{
     ViewBag.Title = "Confirm deletion";
 }
+
 @section breadcrumb {
-<a class="govuk-back-link" href="@Model.BackUrl">Back</a>
+    <a class="govuk-back-link" href="@Model.BackUrl">Back</a>
 }
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <partial name="_validationSummary" /> 
-            <div class="govuk-caption-xl">Manage a standard</div>
-            <h1 class="govuk-heading-xl">Are you sure you want to delete this standard?</h1>
-            <form method="post" asp-route="@RouteNames.PostConfirmDeleteStandard" enctype="multipart/form-data" novalidate>
-                <input type="hidden" asp-for="BackUrl" />
-                <input type="hidden" asp-for="CancelUrl" />
-                <input type="hidden" asp-for="StandardInformation.LarsCode" />
-                <div class="grid-row">
-                    <div class="column-two-thirds">
-                        <table class="govuk-table" aria-describedby="ConfirmRegulatedStandard">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th class="govuk-table__header" scope="col" colspan="2"> </th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell">
-                                        <span class="app-task-list__task-name">
-                                            <strong>
-                                                Standard
-                                            </strong>
-                                        </span>
-                                    </td>
-                                    <td class="govuk-table__cell">
-                                        @Model.StandardInformation.CourseDisplayName
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell">
-                                        <span class="app-task-list__task-name">
-                                            <strong>
-                                                IFATE reference
-                                            </strong>
-                                        </span>
-                                    </td>
-                                    <td class="govuk-table__cell">
-                                        @Model.StandardInformation.IfateReferenceNumber
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell">
-                                        <span class="app-task-list__task-name">
-                                            <strong>
-                                                Version
-                                            </strong>
-                                        </span>
-                                    </td>
-                                    <td class="govuk-table__cell">
-                                        @Model.StandardInformation.Version
-                                    </td>
-                                </tr>
-                                <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell">
-                                        <span class="app-task-list__task-name">
-                                            <strong>
-                                                Sector
-                                            </strong>
-                                        </span>
-                                    </td>
-                                    <td class="govuk-table__cell">
-                                        @Model.StandardInformation.Sector
-                                    </td>
-                                </tr>
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell">
-                                    <span class="app-task-list__task-name">
-                                        <strong>
-                                            LARS code
-                                        </strong>
-                                    </span>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    @Model.StandardInformation.LarsCode
-                                </td>
-                            </tr>
-                            @if (!string.IsNullOrEmpty(Model.StandardInformation.RegulatorName))
-                            {
-                                <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell">
-                                        <span class="app-task-list__task-name">
-                                            <strong>
-                                                Regulator
-                                            </strong>
-                                        </span>
-                                    </td>
-                                    <td class="govuk-table__cell">
-                                        @Model.StandardInformation.RegulatorName
-                                    </td>
-                                </tr>
-                            }
-                            </tbody>
-                        </table>
-                    </div>
 
-                    <p class='govuk-body'>This standard will be removed from your record. It will no longer show as training that you deliver.</p>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <partial name="_validationSummary" /> 
+        <span class="govuk-caption-xl">Manage a standard</span>
+        <h1 class="govuk-heading-xl">Are you sure you want to delete this standard?</h1>
+        <form method="post" asp-route="@RouteNames.PostConfirmDeleteStandard" enctype="multipart/form-data" novalidate>
+            <input type="hidden" asp-for="BackUrl" />
+            <input type="hidden" asp-for="CancelUrl" />
+            <input type="hidden" asp-for="StandardInformation.LarsCode" />
 
-                </div>
-                <div class="govuk-button-group">
-                    <button id="DeleteStandard" class="govuk-button govuk-button--warning" data-module="govuk-button" data-disable-on-submit="true">
-                        Delete standard
-                    </button>
-                    <a id="Cancel" href="@Model.CancelUrl" class="govuk-link">Cancel</a>
-                </div>
-            </form>
-        </div>
+            <table class="govuk-table">
+                <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">
+                            Standard
+                        </th>
+                        <td class="govuk-table__cell">
+                            @Model.StandardInformation.CourseDisplayName
+                        </td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">
+                            IFATE reference
+                        </th>
+                        <td class="govuk-table__cell">
+                            @Model.StandardInformation.IfateReferenceNumber
+                        </td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">
+                            Version
+                        </th>
+                        <td class="govuk-table__cell">
+                            @Model.StandardInformation.Version
+                        </td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">
+                            Sector
+                        </th>
+                        <td class="govuk-table__cell">
+                            @Model.StandardInformation.Sector
+                        </td>
+                    </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">
+                            LARS code
+                        </th>
+                        <td class="govuk-table__cell">
+                            @Model.StandardInformation.LarsCode
+                        </td>
+                    </tr>
+                @if (!string.IsNullOrEmpty(Model.StandardInformation.RegulatorName))
+                {
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">
+                            Regulator
+                        </th>
+                        <td class="govuk-table__cell">
+                            @Model.StandardInformation.RegulatorName
+                        </td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+            
+
+            <p>This standard will be removed from your record. It will no longer show as training that you deliver.</p>
+
+
+            <div class="govuk-button-group">
+                <button id="DeleteStandard" class="govuk-button govuk-button--warning" data-module="govuk-button" data-disable-on-submit="true">
+                    Delete standard
+                </button>
+                <a id="Cancel" href="@Model.CancelUrl" class="govuk-link">Cancel</a>
+            </div>
+        </form>
     </div>
+</div>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ConfirmRegulatedStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ConfirmRegulatedStandard.cshtml
@@ -7,77 +7,73 @@
 @section breadcrumb {
 <a class="govuk-back-link" href="@Model.BackLink">Back</a>
 }
-<main class="govuk-main-wrapper " id="main-content" role="main">
 
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-            <partial name="_validationSummary" /> 
-            <div class="govuk-caption-xl">Manage a standard</div>
-            <h1 class="govuk-heading-xl">This is a regulated standard</h1>
-            <form method="post" asp-route="@RouteNames.PostConfirmRegulatedStandard" enctype="multipart/form-data" novalidate>
-                <input type="hidden" asp-for="RegulatorName" />
-                <input type="hidden" asp-for="BackLink" />
-                <input type="hidden" asp-for="CancelLink" />
-                <input type="hidden" asp-for="RefererLink" />
-               
-                <table class="govuk-table">
-                    <caption class="govuk-visually-hidden">Displays the regulator information</caption>
-                    <tbody class="govuk-table__body">
-                        <tr class="govuk-table__row">
-                            <th scope="row" class="govuk-table__header">
-                                Regulator
-                            </th>
-                            <td class="govuk-table__cell">
-                                @Model.RegulatorName
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <partial name="_validationSummary" /> 
+        <div class="govuk-caption-xl">Manage a standard</div>
+        <h1 class="govuk-heading-xl">This is a regulated standard</h1>
+        <form method="post" asp-route="@RouteNames.PostConfirmRegulatedStandard" enctype="multipart/form-data" novalidate>
+            <input type="hidden" asp-for="RegulatorName" />
+            <input type="hidden" asp-for="BackLink" />
+            <input type="hidden" asp-for="CancelLink" />
+            <input type="hidden" asp-for="RefererLink" />
+            
+            <table class="govuk-table">
+                <caption class="govuk-visually-hidden">Displays the regulator information</caption>
+                <tbody class="govuk-table__body">
+                    <tr class="govuk-table__row">
+                        <th scope="row" class="govuk-table__header">
+                            Regulator
+                        </th>
+                        <td class="govuk-table__cell">
+                            @Model.RegulatorName
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
 
-                <div class="govuk-form-group" esfa-validation-marker-for="IsApprovedByRegulator">
-                    <span class="govuk-error-message" asp-validation-for="IsApprovedByRegulator"></span>
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                            <h2 class="govuk-fieldset__heading">
-                                Have you been approved by the regulator to deliver this standard?
-                            </h2>
-                        </legend>
-                        <div class="govuk-radios">
+            <div class="govuk-form-group" esfa-validation-marker-for="IsApprovedByRegulator">
+                <span class="govuk-error-message" asp-validation-for="IsApprovedByRegulator"></span>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                        Have you been approved by the regulator to deliver this standard?
+                    </legend>
+                    <div class="govuk-radios">
 
-                            <div class="govuk-radios__item">
+                        <div class="govuk-radios__item">
 
-                                <input class="govuk-radios__input" id="ConfirmRegulatedStandard-Yes"
-                                        name="IsApprovedByRegulator" type="radio" value="true" 
-                                        asp-for="IsApprovedByRegulator" sfa-validationerror-class="form-control-error">
-                                <label class="govuk-label govuk-radios__label" for="ConfirmRegulatedStandard-Yes">
-                                    Yes
-                                </label>
+                            <input class="govuk-radios__input" id="ConfirmRegulatedStandard-Yes"
+                                    name="IsApprovedByRegulator" type="radio" value="true" 
+                                    asp-for="IsApprovedByRegulator" sfa-validationerror-class="form-control-error">
+                            <label class="govuk-label govuk-radios__label" for="ConfirmRegulatedStandard-Yes">
+                                Yes
+                            </label>
 
-                            </div>
-
-                            <div class="govuk-radios__item">
-
-                                <input class="govuk-radios__input" id="ConfirmRegulatedStandard-No"
-                                        name="IsApprovedByRegulator" type="radio" value="false" 
-                                        asp-for="IsApprovedByRegulator" sfa-validationerror-class="form-control-error">
-                                <label class="govuk-label govuk-radios__label" for="ConfirmRegulatedStandard-No">
-                                    No
-                                </label>
-
-                            </div>
                         </div>
-                    </fieldset>
-                </div>
 
-                <partial name="~/Views/Standards/StandardsPartials/_RegulatedStandardInfo.cshtml" />
-             
-                <div class="govuk-button-group">
-                    <button id="SaveAndContinue" class="govuk-button" data-module="govuk-button" data-disable-on-submit="true">
-                        Save and continue
-                    </button>
-                    <a id="Cancel" href="@Model.CancelLink" class="govuk-link">Cancel</a>
-                </div>
-            </form>
-        </div>
+                        <div class="govuk-radios__item">
+
+                            <input class="govuk-radios__input" id="ConfirmRegulatedStandard-No"
+                                    name="IsApprovedByRegulator" type="radio" value="false" 
+                                    asp-for="IsApprovedByRegulator" sfa-validationerror-class="form-control-error">
+                            <label class="govuk-label govuk-radios__label" for="ConfirmRegulatedStandard-No">
+                                No
+                            </label>
+
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+
+            <partial name="~/Views/Standards/StandardsPartials/_RegulatedStandardInfo.cshtml" />
+            
+            <div class="govuk-button-group">
+                <button id="SaveAndContinue" class="govuk-button" data-module="govuk-button" data-disable-on-submit="true">
+                    Save and continue
+                </button>
+                <a id="Cancel" href="@Model.CancelLink" class="govuk-link">Cancel</a>
+            </div>
+        </form>
     </div>
-</main>
+</div>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ConfirmRegulatedStandard.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ConfirmRegulatedStandard.cshtml
@@ -19,68 +19,58 @@
                 <input type="hidden" asp-for="BackLink" />
                 <input type="hidden" asp-for="CancelLink" />
                 <input type="hidden" asp-for="RefererLink" />
-                <div class="grid-row">
-                    <div class="column-two-thirds">
-                        <table class="govuk-table" aria-describedby="ConfirmRegulatedStandard">
-                            <thead class="govuk-table__head">
-                                <tr class="govuk-table__row">
-                                    <th class="govuk-table__header" scope="col" colspan="2"> </th>
-                                </tr>
-                            </thead>
-                            <tbody class="govuk-table__body">
-                                <tr class="govuk-table__row">
-                                    <td class="govuk-table__cell">
-                                        <span class="app-task-list__task-name">
-                                            <strong>
-                                                Regulator
-                                            </strong>
-                                        </span>
-                                    </td>
-                                    <td class="govuk-table__cell">
-                                        @Model.RegulatorName
-                                    </td>
-                                    <td class="govuk-table__cell">
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <div class="govuk-form-group" esfa-validation-marker-for="IsApprovedByRegulator">
-                            <span class="govuk-error-message" asp-validation-for="IsApprovedByRegulator"></span>
-                            <fieldset class="govuk-fieldset">
-                                <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                                    <h2 class="govuk-fieldset__heading">
-                                        Have you been approved by the regulator to deliver this standard?
-                                    </h2>
-                                </legend>
-                                <div class="govuk-radios">
+               
+                <table class="govuk-table">
+                    <caption class="govuk-visually-hidden">Displays the regulator information</caption>
+                    <tbody class="govuk-table__body">
+                        <tr class="govuk-table__row">
+                            <th scope="row" class="govuk-table__header">
+                                Regulator
+                            </th>
+                            <td class="govuk-table__cell">
+                                @Model.RegulatorName
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
 
-                                    <div class="govuk-radios__item">
+                <div class="govuk-form-group" esfa-validation-marker-for="IsApprovedByRegulator">
+                    <span class="govuk-error-message" asp-validation-for="IsApprovedByRegulator"></span>
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                            <h2 class="govuk-fieldset__heading">
+                                Have you been approved by the regulator to deliver this standard?
+                            </h2>
+                        </legend>
+                        <div class="govuk-radios">
 
-                                        <input id="IsApprovedByRegulator" class="govuk-radios__input" id="ConfirmRegulatedStandard-Yes"
-                                               name="IsApprovedByRegulator" type="radio" value="true" 
-                                               asp-for="IsApprovedByRegulator" sfa-validationerror-class="form-control-error">
-                                        <label class="govuk-label govuk-radios__label" for="ConfirmRegulatedStandard-Yes">
-                                            Yes
-                                        </label>
+                            <div class="govuk-radios__item">
 
-                                    </div>
+                                <input class="govuk-radios__input" id="ConfirmRegulatedStandard-Yes"
+                                        name="IsApprovedByRegulator" type="radio" value="true" 
+                                        asp-for="IsApprovedByRegulator" sfa-validationerror-class="form-control-error">
+                                <label class="govuk-label govuk-radios__label" for="ConfirmRegulatedStandard-Yes">
+                                    Yes
+                                </label>
 
-                                    <div class="govuk-radios__item">
+                            </div>
 
-                                        <input id="IsApprovedByRegulator-No" class="govuk-radios__input" id="ConfirmRegulatedStandard-No"
-                                               name="IsApprovedByRegulator" type="radio" value="false" 
-                                               asp-for="IsApprovedByRegulator" sfa-validationerror-class="form-control-error">
-                                        <label class="govuk-label govuk-radios__label" for="ConfirmRegulatedStandard-No">
-                                            No
-                                        </label>
+                            <div class="govuk-radios__item">
 
-                                    </div>
-                                </div>
-                            </fieldset>
+                                <input class="govuk-radios__input" id="ConfirmRegulatedStandard-No"
+                                        name="IsApprovedByRegulator" type="radio" value="false" 
+                                        asp-for="IsApprovedByRegulator" sfa-validationerror-class="form-control-error">
+                                <label class="govuk-label govuk-radios__label" for="ConfirmRegulatedStandard-No">
+                                    No
+                                </label>
+
+                            </div>
                         </div>
-                        <partial name="~/Views/Standards/StandardsPartials/_RegulatedStandardInfo.cshtml" />
-                    </div>
+                    </fieldset>
                 </div>
+
+                <partial name="~/Views/Standards/StandardsPartials/_RegulatedStandardInfo.cshtml" />
+             
                 <div class="govuk-button-group">
                     <button id="SaveAndContinue" class="govuk-button" data-module="govuk-button" data-disable-on-submit="true">
                         Save and continue

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/EditProviderCourseRegions.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/EditProviderCourseRegions.cshtml
@@ -30,8 +30,8 @@
                     {
                         <li class="govuk-grid-column-one-half">
                             <div class="govuk-checkboxes__item  govuk-checkboxes--small">
-                                <input class="govuk-checkboxes__input" id="SelectedSubRegions" name="SelectedSubRegions" type="checkbox" value="@location.Id" asp-for="@location.IsSelected">
-                                <label class="govuk-label govuk-checkboxes__label" for="SubRegions" asp-for="@location.SubregionName">
+                                <input class="govuk-checkboxes__input" id="SelectedSubRegions-@location.Id" name="SelectedSubRegions" type="checkbox" value="@location.Id" asp-for="@location.IsSelected">
+                                <label class="govuk-label govuk-checkboxes__label" id="SelectedSubRegions-@location.Id">
                                     @location.SubregionName
                                 </label>
                             </div>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/EditProviderCourseRegions.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/EditProviderCourseRegions.cshtml
@@ -31,7 +31,7 @@
                         <li class="govuk-grid-column-one-half">
                             <div class="govuk-checkboxes__item  govuk-checkboxes--small">
                                 <input class="govuk-checkboxes__input" id="SelectedSubRegions-@location.Id" name="SelectedSubRegions" type="checkbox" value="@location.Id" asp-for="@location.IsSelected">
-                                <label class="govuk-label govuk-checkboxes__label" id="SelectedSubRegions-@location.Id">
+                                <label class="govuk-label govuk-checkboxes__label" for="SelectedSubRegions-@location.Id">
                                     @location.SubregionName
                                 </label>
                             </div>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ViewStandardDetails.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ViewStandardDetails.cshtml
@@ -58,7 +58,7 @@
                         <td class="govuk-table__cell">
                             @Model.ApprovedByRegulatorStatus()
                         </td>
-                        <td class="govuk-table__cell">
+                        <td class="govuk-table__cell govuk-table__cell--numeric">
                             <a href="@Model.ConfirmRegulatedStandardUrl" aria-describedby="change-approved-regulator" class="govuk-link">
                                 Change
                             </a>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ViewStandardDetails.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ViewStandardDetails.cshtml
@@ -59,8 +59,8 @@
                             @Model.ApprovedByRegulatorStatus()
                         </td>
                         <td class="govuk-table__cell govuk-table__cell--numeric">
-                            <a href="@Model.ConfirmRegulatedStandardUrl" aria-describedby="change-approved-regulator" class="govuk-link">
-                                Change
+                            <a href="@Model.ConfirmRegulatedStandardUrl" class="govuk-link">
+                                Change<span class="govuk-visually-hidden"> the regulated information</span>
                             </a>
                         </td>
                     </tr>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ViewStandardDetails.cshtml
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Views/Standards/ViewStandardDetails.cshtml
@@ -24,7 +24,7 @@
     <div class="govuk-grid-column-two-thirds">
         <partial name="_StandardContactInformation" for="ContactInformation" />
         <p class="govuk-body">
-            <a href="@Model.EditContactDetailsUrl" aria-describedby="Update-contact-details" class="govuk-link">
+            <a href="@Model.EditContactDetailsUrl" class="govuk-link">
                 Update these contact details
             </a>
         </p>


### PR DESCRIPTION
Standard details page

- Removed aria-describedby="Update-contact-details" from "Update these contact details" Link - wasn’t needed and didn’t link anywhere 

Confirm Regulated Standard page

- Remove duplicated <main> tag
- Removed the aria-describedby="ConfirmRegulatedStandard" from the Table
- Tidied the html used in the table 
- Removed the duplicated IDs on the radio input so the labels can now link up

Select Regions for Course Page

- Associate the labels with the checkboxes 

Confirm Deletion Delete Standard

- Removed the aria-describedby="ConfirmRegulatedStandard" from the Table
- Tidied the html used in the table 

Confirm Standard Add a Standard Page

- Remove additional H1 and use regular legend 

Select a Standard Page

- Associate the label with the select 

Venue and Delivery Page

- Removed the aria-describedby=
- Associate the label with the select 