### PR TITLE
removed unused variable group

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -116,7 +116,6 @@ stages:
   variables:
   - group: MO Management Resources
   - group: MO Shared Resources
-  - group: MO das-roatp-coursemanagement-web
   jobs:
   - template: pipeline-templates/job/deploy.yml
     parameters:


### PR DESCRIPTION
**MO das-roatp-coursemanagement-web** variable group has been removed from the pipeline deployment file as this is no longer in use