### PR TITLE
FAI-800 Managing Standards (Courses for FAT) DfESignIn

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -61,13 +61,13 @@
             "defaultValue": "[utcNow()]"
         }
     },
-    "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
-        "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
-        "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
-        "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
-        "configNames": "SFA.DAS.Roatp.CourseManagement.Web"
-    },
+  "variables": {
+    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
+    "resourceNamePrefix": "[toLower(concat('das-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
+    "resourceGroupName": "[concat(variables('resourceNamePrefix'), '-rg')]",
+    "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
+    "configNames": "SFA.DAS.Roatp.CourseManagement.Web,SFA.DAS.Provider.DfeSignIn"
+  },
     "resources": [
         {
             "apiVersion": "2021-04-01",

--- a/src/SFA.DAS.Roatp.CourseManagement.Web.sln
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31911.196
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33723.286
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Roatp.CourseManagement.Web", "SFA.DAS.Roatp.CourseManagement.Web\SFA.DAS.Roatp.CourseManagement.Web.csproj", "{0565A2D0-36F4-4718-B99A-67088A7E015D}"
 EndProject
@@ -15,11 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Roatp.CourseManagem
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Roatp.CourseManagement.Infrastructure", "SFA.DAS.Roatp.CourseManagement.Infrastructure\SFA.DAS.Roatp.CourseManagement.Infrastructure.csproj", "{C8A75774-54D6-42D1-9C01-4D2FF7798D15}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.Roatp.CourseManagement.Application.UnitTests", "SFA.DAS.Roatp.CourseManagement.Application.UnitTests\SFA.DAS.Roatp.CourseManagement.Application.UnitTests.csproj", "{62F5339C-7EEA-4BE2-9F6D-D4CD5281B045}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Roatp.CourseManagement.Application.UnitTests", "SFA.DAS.Roatp.CourseManagement.Application.UnitTests\SFA.DAS.Roatp.CourseManagement.Application.UnitTests.csproj", "{62F5339C-7EEA-4BE2-9F6D-D4CD5281B045}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.Roatp.CourseManagement.Domain.UnitTests", "SFA.DAS.Roatp.CourseManagement.Domain.UnitTests\SFA.DAS.Roatp.CourseManagement.Domain.UnitTests.csproj", "{8ECAAD0B-2DD7-4F7D-BD15-A5A90236821D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Roatp.CourseManagement.Domain.UnitTests", "SFA.DAS.Roatp.CourseManagement.Domain.UnitTests\SFA.DAS.Roatp.CourseManagement.Domain.UnitTests.csproj", "{8ECAAD0B-2DD7-4F7D-BD15-A5A90236821D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SFA.DAS.Roatp.CourseManagement.Infrastructure.UnitTests", "SFA.DAS.Roatp.CourseManagement.Infrastructure.UnitTests\SFA.DAS.Roatp.CourseManagement.Infrastructure.UnitTests.csproj", "{DF3ABE23-443A-4789-8459-2ADA7F5662A8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SFA.DAS.Roatp.CourseManagement.Infrastructure.UnitTests", "SFA.DAS.Roatp.CourseManagement.Infrastructure.UnitTests\SFA.DAS.Roatp.CourseManagement.Infrastructure.UnitTests.csproj", "{DF3ABE23-443A-4789-8459-2ADA7F5662A8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/ProviderAccountController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/ProviderAccountController.cs
@@ -1,7 +1,10 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authentication.WsFederation;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using SFA.DAS.Roatp.CourseManagement.Domain.Configuration;
 using SFA.DAS.Roatp.CourseManagement.Web.Infrastructure;
 
 namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers
@@ -9,9 +12,20 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers
     [ExcludeFromCodeCoverage]
     public class ProviderAccountController : Controller
     {
+        private readonly IOptions<RoatpCourseManagement> _configOptions;
+
+        public ProviderAccountController(IOptions<RoatpCourseManagement> configOptions)
+        {
+            _configOptions = configOptions;
+        }
+
         [Route("signout", Name = RouteNames.ProviderSignOut)]
         public IActionResult SignOut()
         {
+            var authScheme = _configOptions.Value.UseDfESignIn
+                ? WsFederationDefaults.AuthenticationScheme
+                : OpenIdConnectDefaults.AuthenticationScheme;
+
             return SignOut(
                 new Microsoft.AspNetCore.Authentication.AuthenticationProperties
                 {
@@ -19,7 +33,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers
                     AllowRefresh = true
                 },
                 CookieAuthenticationDefaults.AuthenticationScheme,
-                WsFederationDefaults.AuthenticationScheme);
+                authScheme);
         }
     }
 }

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Infrastructure/Authorization/CustomServiceRole.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Infrastructure/Authorization/CustomServiceRole.cs
@@ -1,0 +1,11 @@
+﻿using SFA.DAS.DfESignIn.Auth.Enums;
+using SFA.DAS.DfESignIn.Auth.Interfaces;
+
+namespace SFA.DAS.Roatp.CourseManagement.Web.Infrastructure.Authorization
+{
+    public class CustomServiceRole : ICustomServiceRole
+    {
+        public string RoleClaimType => ProviderClaims.Service;
+        public CustomServiceRoleValueType RoleValueType => CustomServiceRoleValueType.Code;
+    }
+}

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/SFA.DAS.Roatp.CourseManagement.Web.csproj
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/SFA.DAS.Roatp.CourseManagement.Web.csproj
@@ -14,17 +14,19 @@
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.10" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.10" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.10" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.1.4" />
     <PackageReference Include="SFA.DAS.Authorization.Mvc" Version="6.0.97" />
     <PackageReference Include="SFA.DAS.Configuration.AzureTableStorage" Version="3.0.84" />
+    <PackageReference Include="SFA.DAS.DfESignIn.Auth" Version="17.1.48" />
     <PackageReference Include="SFA.DAS.NLog.Targets.Redis" Version="1.2.1" />
     <PackageReference Include="SFA.DAS.Provider.Shared.UI" Version="2.0.24" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.10" />
     <PackageReference Include="SFA.DAS.ProviderUrlHelper" Version="1.1.1043" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.30.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Startup.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Startup.cs
@@ -89,8 +89,7 @@ namespace SFA.DAS.Roatp.CourseManagement.Web
             }
             else
             {
-                var providerConfig = _configuration.GetSection(nameof(ProviderIdams)).Get<ProviderIdams>();
-                services.AddAndConfigureProviderAuthentication(providerConfig);
+                services.AddAndConfigureProviderAuthentication(_configuration);
             }
 
             services.Configure<IISServerOptions>(options => { options.AutomaticAuthentication = false; });

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/appsettings.json
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "ConfigurationStorageConnectionString": "UseDevelopmentStorage=true;",
-  "ConfigNames": "SFA.DAS.Roatp.CourseManagement.Web",
+  "ConfigNames": "SFA.DAS.Roatp.CourseManagement.Web,SFA.DAS.Provider.DfeSignIn",
   "EnvironmentName": "LOCAL",
   "Version": "1.0",
   "APPINSIGHTS_INSTRUMENTATIONKEY": "",


### PR DESCRIPTION
Story: The purpose of this story is to put behind a feature toggle the DfESignIn authentication, replacing the existing Pirean, SAML based authentication.

Link: https://skillsfundingagency.atlassian.net/browse/FAI-800

Details
1. Extended SFA.DAS.Roatp.CourseManagement.Web Config to hold the UseDfeSignIn property. "UseDfeSignIn": true.
2. Added logic/condition in ServiceCollectionExtension to check if the UseDfeSignIn property is set to true, so that DfESignin happens.
3. Check the Authentication scheme based on UseDfeSignIn property and use the relevant sign-out Authentication Scheme.

![image](https://github.com/SkillsFundingAgency/das-roatp-coursemanagement-web/assets/2102434/b208d35a-faec-4be9-88c9-e9ac8fcfd4ae)
