### PR TITLE
FAI-800 Managing Standards (Courses for FAT)

### DIFF
--- a/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/ProviderAccountController.cs
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/Controllers/ProviderAccountController.cs
@@ -22,9 +22,10 @@ namespace SFA.DAS.Roatp.CourseManagement.Web.Controllers
         [Route("signout", Name = RouteNames.ProviderSignOut)]
         public IActionResult SignOut()
         {
+            // choose the authentication scheme based on the UseDfESignIn property value.
             var authScheme = _configOptions.Value.UseDfESignIn
-                ? WsFederationDefaults.AuthenticationScheme
-                : OpenIdConnectDefaults.AuthenticationScheme;
+                ? OpenIdConnectDefaults.AuthenticationScheme
+                : WsFederationDefaults.AuthenticationScheme;
 
             return SignOut(
                 new Microsoft.AspNetCore.Authentication.AuthenticationProperties

--- a/src/SFA.DAS.Roatp.CourseManagement.Web/SFA.DAS.Roatp.CourseManagement.Web.csproj
+++ b/src/SFA.DAS.Roatp.CourseManagement.Web/SFA.DAS.Roatp.CourseManagement.Web.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.10" />
     <PackageReference Include="SFA.DAS.ProviderUrlHelper" Version="1.1.1043" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.70" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.30.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.27.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Commit Details:
1. Fixing the Pre-Prod issue MissingMethodException: ValidateLifetimeAndIssueAfterSignatureNotValidatedSaml
Downgraded System.IdentityModel.Tokens.Jwt: 6.27.0

2. SignOut Authentication Scheme changes in the ProviderAccountController

https://skillsfundingagency.atlassian.net/browse/FAI-800

<img width="1280" alt="image" src="https://github.com/SkillsFundingAgency/das-roatp-coursemanagement-web/assets/2102434/6beac8ab-3aab-430b-82d5-67cba89a0ddf">
